### PR TITLE
feat(kvv2): add support to key value version 2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
                                             given tries to get the address from
                                             the env var VAULT_TOKEN.
 	-f, --force                          Override the current .env file
+  --kvv2                               Uses key-value 2 vault api
 ```
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
                                             given tries to get the address from
                                             the env var VAULT_TOKEN.
 	-f, --force                          Override the current .env file
-  --kvv2                               Uses key-value 2 vault api
+        --kvv2                               Uses key-value 2 vault api
 ```
 
 ## Contributors


### PR DESCRIPTION
Hi, I start using vault this weekend and setup secret engine key value version 2.

There is some changes, now it has `metadata` and `data` field paths on api.

I added a `kvv2` option to use this new version.

Thanks!